### PR TITLE
[unit test] Chapter 15 examples

### DIFF
--- a/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/LoginControllerUnitTests.java
+++ b/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/LoginControllerUnitTests.java
@@ -1,0 +1,54 @@
+package com.github.hojoungjang.pt2_implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import com.github.hojoungjang.pt2_implementation.controllers.LoginController;
+import com.github.hojoungjang.pt2_implementation.processor.LoginProcessor;
+import com.github.hojoungjang.pt2_implementation.service.LoggedUserManagementService;
+import com.github.hojoungjang.pt2_implementation.service.LoginCountService;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginControllerUnitTests {
+    @Mock
+    private Model model;
+
+    @Mock
+    private LoginProcessor loginProcessor;
+
+    @Mock
+    private LoggedUserManagementService lumService;
+
+    @Mock
+    private LoginCountService loginCountService;
+
+    @InjectMocks
+    private LoginController loginController;
+
+    @Test
+    public void loginSucceedsTest() {
+        given(loginProcessor.login()).willReturn(true);
+
+        String result = loginController.login("username", "password", model);
+
+        assertEquals(result, "redirect:/main");
+    }
+
+    @Test
+    public void loginFailsTest() {
+        given(loginProcessor.login()).willReturn(false);
+
+        String result = loginController.login("username", "password", model);
+
+        assertEquals(result, "login.html");
+        verify(model).addAttribute("message", "Login failed!");
+    }
+}

--- a/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/TransferServiceSpringIntegrationTests.java
+++ b/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/TransferServiceSpringIntegrationTests.java
@@ -1,0 +1,45 @@
+package com.github.hojoungjang.pt2_implementation;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.github.hojoungjang.pt2_implementation.model.Account;
+import com.github.hojoungjang.pt2_implementation.repository.AccountRepository;
+import com.github.hojoungjang.pt2_implementation.service.TransferService;
+
+@SpringBootTest
+public class TransferServiceSpringIntegrationTests {
+    
+    @MockitoBean
+    private AccountRepository accountRepo;
+
+    @Autowired
+    private TransferService transferService;
+
+    @Test
+    void transferMoneyTest() {
+        Account sender = new Account();
+        sender.setId(1L);
+        sender.setAmount(new BigDecimal(1000));
+
+        Account receiver = new Account();
+        receiver.setId(2L);
+        receiver.setAmount(new BigDecimal(1000));
+
+        when(accountRepo.findById(1L)).thenReturn(Optional.of(sender));
+        when(accountRepo.findById(2L)).thenReturn(Optional.of(receiver));
+
+        transferService.transferMoney(1L, 2L, new BigDecimal(100));
+
+        verify(accountRepo).changeAmount(1L, new BigDecimal(900));
+        verify(accountRepo).changeAmount(2L, new BigDecimal(1100));
+    }
+}

--- a/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/TransferServiceUnitTests.java
+++ b/pt2-implementation/src/test/java/com/github/hojoungjang/pt2_implementation/TransferServiceUnitTests.java
@@ -1,0 +1,40 @@
+package com.github.hojoungjang.pt2_implementation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.github.hojoungjang.pt2_implementation.model.Account;
+import com.github.hojoungjang.pt2_implementation.repository.AccountRepository;
+import com.github.hojoungjang.pt2_implementation.service.TransferService;
+
+public class TransferServiceUnitTests {
+    @Test
+    @DisplayName("Test the amount is transferred from one account to another if no exception occurs.")
+    public void transferMoneyHappyFlow() {
+        AccountRepository accountRepo = mock(AccountRepository.class);
+        TransferService transferService = new TransferService(accountRepo);
+
+        Account sender = new Account();
+        sender.setId(1);
+        sender.setAmount(new BigDecimal(1000));
+
+        Account receiver = new Account();
+        receiver.setId(2);
+        receiver.setAmount(new BigDecimal(1000));
+
+        given(accountRepo.findById(sender.getId())).willReturn(Optional.of(sender));
+        given(accountRepo.findById(receiver.getId())).willReturn(Optional.of(receiver));
+
+        transferService.transferMoney(sender.getId(), receiver.getId(), new BigDecimal(100));
+
+        verify(accountRepo).changeAmount(sender.getId(), new BigDecimal(900));
+        verify(accountRepo).changeAmount(receiver.getId(), new BigDecimal(1100));
+    }
+}


### PR DESCRIPTION
#### inline mocks are possible
```java
AccountRepository accountRepo = mock(AccountRepository.class);
```

#### Often it's easier to manage and read code where mocks are created and injected through test class' annotated field
```
@ExtendWith(MockitoExtension.class)
public class TransferServiceWithAnnotationsUnitTests {
 
  @Mock
  private AccountRepository accountRepository;
 
  @InjectMocks
  private TransferService transferService;
}
```

#### Use `@SpringBootTest` to create integration test class
This way, the test starts your spring application with spring context and the beans.
You will be able to test if your spring app is able to boot up and the components/beans are properly wired together.

#### What would be the difference between `given()` and `when()`???